### PR TITLE
fix: fix external dependency detection in project-hcl-files flag

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -567,7 +567,7 @@ func createHclProject(ctx context.Context, sourcePaths []string, workingDir stri
 				return nil, err
 			}
 
-			if !strings.Contains(absolutePath, filepath.ToSlash(workingDir)) {
+			if strings.HasPrefix(relativePath, "..") {
 				relativeDependencies = append(relativeDependencies, filepath.ToSlash(relativePath))
 			}
 		}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -607,6 +607,17 @@ func TestRemoteModuleSourceTerraformRegistry(t *testing.T) {
 	})
 }
 
+func TestEnvHCLProjectsWithDeps(t *testing.T) {
+	runTest(t, filepath.Join(testReferenceOutputs, "proj_hcl_with_external_deps.yaml"), []string{
+		"--root",
+		filepath.Join(testFixturesDir, "proj_hcl_with_external_deps", "my-stack"),
+		"--cascade-dependencies",
+		"--project-hcl-files=stack.hcl",
+		"--create-hcl-project-childs=false",
+		"--create-hcl-project-external-childs=false",
+	})
+}
+
 func TestEnvHCLProjectsNoChilds(t *testing.T) {
 	runTest(t, filepath.Join(testReferenceOutputs, "envhcl_nochilds.yaml"), []string{
 		"--root",

--- a/test/fixtures/proj_hcl_with_external_deps/_env/cluster/fargate.hcl
+++ b/test/fixtures/proj_hcl_with_external_deps/_env/cluster/fargate.hcl
@@ -1,0 +1,3 @@
+locals {
+  source_base_url = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}

--- a/test/fixtures/proj_hcl_with_external_deps/my-stack/nested/terragrunt.hcl
+++ b/test/fixtures/proj_hcl_with_external_deps/my-stack/nested/terragrunt.hcl
@@ -1,0 +1,11 @@
+include "stack" {
+  path = find_in_parent_folders("stack.hcl")
+}
+include "env" {
+  path = "${get_terragrunt_dir()}/../../_env/cluster/fargate.hcl"
+  expose = true
+}
+
+terraform {
+  source = include.env.locals.source_base_url
+}

--- a/test/fixtures/proj_hcl_with_external_deps/my-stack/stack.hcl
+++ b/test/fixtures/proj_hcl_with_external_deps/my-stack/stack.hcl
@@ -1,0 +1,3 @@
+locals {
+  environment = "qa"
+}

--- a/test/reference_outputs/envhcl_allchilds.yaml
+++ b/test/reference_outputs/envhcl_allchilds.yaml
@@ -505,6 +505,15 @@ projects:
     - '*.hcl'
     - '*.tf*'
     - '*.tofu*'
+    - ../stack.hcl
+    - ../../_env/cluster/fargate.hcl
+  dir: proj_hcl_with_external_deps/my-stack/nested
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '*.tofu*'
     - '**/*.hcl'
     - '**/*.tf*'
     - '**/*.tofu*'

--- a/test/reference_outputs/envhcl_externalchilds.yaml
+++ b/test/reference_outputs/envhcl_externalchilds.yaml
@@ -418,6 +418,15 @@ projects:
     - '*.hcl'
     - '*.tf*'
     - '*.tofu*'
+    - ../stack.hcl
+    - ../../_env/cluster/fargate.hcl
+  dir: proj_hcl_with_external_deps/my-stack/nested
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '*.tofu*'
     - '**/*.hcl'
     - '**/*.tf*'
     - '**/*.tofu*'

--- a/test/reference_outputs/proj_hcl_with_external_deps.yaml
+++ b/test/reference_outputs/proj_hcl_with_external_deps.yaml
@@ -1,0 +1,16 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '*.tofu*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - '**/*.tofu*'
+    - ../_env/cluster/fargate.hcl
+  dir: .
+version: 3


### PR DESCRIPTION
This commit integrates upstream PR #390 which fixes a bug where not all files were being added when using the --project-hcl-files flag. The issue was in the logic for detecting external dependencies that should be included in the Atlantis project configuration.

Changes:
- Fixed the condition for detecting external dependencies in createHclProject() by replacing `!strings.Contains(absolutePath, filepath.ToSlash(workingDir))` with `strings.HasPrefix(relativePath, "..")` for more accurate relative path detection
- Added comprehensive test case TestEnvHCLProjectsWithDeps with fixture files that demonstrate external dependency inclusion across directory boundaries
- Updated reference output files to include the new test project entry
- Created test fixtures in proj_hcl_with_external_deps/ including:
  - stack.hcl with local environment configuration
  - fargate.hcl with external module source configuration
  - nested/terragrunt.hcl that includes both files and demonstrates the fix

The fix ensures that when using project HCL files, dependencies that are outside the working directory (indicated by relative paths starting with "..") are properly detected and included in the when_modified list for Atlantis autoplan triggers.

This resolves cases where changes to external dependency files would not trigger Atlantis plans for projects that depend on them.